### PR TITLE
chore: add link to 2nd edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 This repo holds the samples from my book: https://leanpub.com/windowskernelprogramming, also available from Amazon at https://www.amazon.com/gp/product/1977593372/
 
 
+> **NOTE:**
+> 
+> **Second Edition** of the book is out. Check it out here - https://leanpub.com/windowskernelprogrammingsecondedition, and also on Amazon at https://www.amazon.com/Windows-Kernel-Programming-Pavel-Yosifovich-ebook/dp/B0BWWWG5ZV/


### PR DESCRIPTION
When you Google, "Windows Kernel Programming", this repo comes first; will be nice to redirect new folks to the 2nd edition book.